### PR TITLE
Spring Application Monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 spring.output.ansi.enabled=always
 #This setting gets rid of the Caused by: java.sql.SQLSyntaxErrorException: Schema 'SA' does not exist exceptions
 spring.jpa.hibernate.ddl-auto=update
+management.endpoints.web.base-path=/actuator
+management.endpoints.web.exposure.include=*
+management.endpoint.health.show-details=always


### PR DESCRIPTION
# Spring Boot Actuator
- Allows you to monitor your app's health and activity
- Opens up and endpoint [localhost:8080/health](http://localhost:8080/health)

# Notes
Unlike in previous versions, Actuator comes with most endpoints disabled.
Thus, the only two available by default are /health and /info.
- To enable all endpoints, add this to application properties `management.endpoints.web.exposure.include=*`
- You an also modify the base path to not have to go through `/actuator` every time

# Default Output from the Actuator Endpoint
```
{"_links":{"self":{"href":"http://localhost:8080/actuator","templated":false},"beans":
{"href":"http://localhost:8080/actuator/beans","templated":false},"caches-cache":
{"href":"http://localhost:8080/actuator/caches/{cache}","templated":true},"caches":
{"href":"http://localhost:8080/actuator/caches","templated":false},"health-path":
{"href":"http://localhost:8080/actuator/health/{*path}","templated":true},"health":
{"href":"http://localhost:8080/actuator/health","templated":false},"info":
{"href":"http://localhost:8080/actuator/info","templated":false},"conditions":
{"href":"http://localhost:8080/actuator/conditions","templated":false},"configprops":
{"href":"http://localhost:8080/actuator/configprops","templated":false},"env":
{"href":"http://localhost:8080/actuator/env","templated":false},"env-toMatch":
{"href":"http://localhost:8080/actuator/env/{toMatch}","templated":true},"loggers":
{"href":"http://localhost:8080/actuator/loggers","templated":false},"loggers-name":
{"href":"http://localhost:8080/actuator/loggers/{name}","templated":true},"heapdump":
{"href":"http://localhost:8080/actuator/heapdump","templated":false},"threaddump":
{"href":"http://localhost:8080/actuator/threaddump","templated":false},"metrics":
{"href":"http://localhost:8080/actuator/metrics","templated":false},"metrics-requiredMetricName":
{"href":"http://localhost:8080/actuator/metrics/{requiredMetricName}","templated":true},"scheduledtasks
":{"href":"http://localhost:8080/actuator/scheduledtasks","templated":false},"mappings":
{"href":"http://localhost:8080/actuator/mappings","templated":false}}}
```

#Beans Used
```
{
	"contexts": {
		"application": {
			"beans": {
				"spring.jpa-org.springframework.boot.autoconfigure.orm.jpa.JpaProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.JpaProperties",
					"resource": null,
					"dependencies": []
				},
				"endpointCachingOperationInvokerAdvisor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.invoker.cache.CachingOperationInvokerAdvisor",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/EndpointAutoConfiguration.class]",
					"dependencies": ["environment"]
				},
				"defaultServletHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.HandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"metricsRestTemplateCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.metrics.web.client.MetricsRestTemplateCustomizer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.class]",
					"dependencies": ["simpleMeterRegistry", "restTemplateExchangeTagsProvider", "management.metrics-org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties"]
				},
				"applicationTaskExecutor": {
					"aliases": ["taskExecutor"],
					"scope": "singleton",
					"type": "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.class]",
					"dependencies": ["taskExecutorBuilder"]
				},
				"persistenceExceptionTranslationPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/dao/PersistenceExceptionTranslationAutoConfiguration.class]",
					"dependencies": ["environment"]
				},
				"spring.data.web-org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties",
					"resource": null,
					"dependencies": []
				},
				"characterEncodingFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.servlet.filter.OrderedCharacterEncodingFilter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfiguration.class]",
					"dependencies": []
				},
				"courseController": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.course.CourseController",
					"resource": "file [/Users/oblavat/personal/course-api-data/target/classes/io/javabrains/course/CourseController.class]",
					"dependencies": ["courseService"]
				},
				"healthEndpointGroups": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.AutoConfiguredHealthEndpointGroups",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "healthEndpointProperties"]
				},
				"sortCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration$$Lambda$928/0x00000008018de440",
					"resource": "class path resource [org/springframework/boot/autoconfigure/data/web/SpringDataWebAutoConfiguration.class]",
					"dependencies": []
				},
				"webEndpointDiscoverer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.annotation.WebEndpointDiscoverer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": ["endpointOperationParameterMapper", "endpointMediaTypes"]
				},
				"org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.MultipartAutoConfiguration",
					"resource": null,
					"dependencies": ["spring.servlet.multipart-org.springframework.boot.autoconfigure.web.servlet.MultipartProperties"]
				},
				"org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration$DispatcherServletRegistrationConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration$DispatcherServletRegistrationConfiguration",
					"resource": null,
					"dependencies": []
				},
				"preserveErrorControllerTargetClassPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$PreserveErrorControllerTargetClassPostProcessor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$JacksonObjectMapperBuilderConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$JacksonObjectMapperBuilderConfiguration",
					"resource": null,
					"dependencies": []
				},
				"logbackMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.logging.LogbackMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/LogbackMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"jdbcTemplate": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.jdbc.core.JdbcTemplate",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jdbc/JdbcTemplateConfiguration.class]",
					"dependencies": ["dataSource", "spring.jdbc-org.springframework.boot.autoconfigure.jdbc.JdbcProperties"]
				},
				"management.info-org.springframework.boot.actuate.autoconfigure.info.InfoContributorProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.info.InfoContributorProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration",
					"resource": null,
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties"]
				},
				"webEndpointPathMapper": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.MappingWebEndpointPathMapper",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.trace.http.HttpTraceEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaConfiguration",
					"resource": null,
					"dependencies": ["dataSource", "spring.jpa-org.springframework.boot.autoconfigure.orm.jpa.JpaProperties", "org.springframework.beans.factory.support.DefaultListableBeanFactory@35399441", "spring.jpa.hibernate-org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.cache.CachesEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.cache.CachesEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"propertySourcesPlaceholderConfigurer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.context.support.PropertySourcesPlaceholderConfigurer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$EnableTransactionManagementConfiguration$CglibAutoProxyConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$EnableTransactionManagementConfiguration$CglibAutoProxyConfiguration",
					"resource": null,
					"dependencies": []
				},
				"openEntityManagerInViewInterceptor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration$JpaWebConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration",
					"resource": null,
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "management.endpoints.jmx-org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointProperties"]
				},
				"jmxMBeanExporter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.jmx.JmxEndpointExporter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/jmx/JmxEndpointAutoConfiguration.class]",
					"dependencies": ["mbeanServer", "environment", "jmxAnnotationEndpointDiscoverer"]
				},
				"beanNameViewResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.view.BeanNameViewResolver",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration$WhitelabelErrorViewConfiguration.class]",
					"dependencies": []
				},
				"restTemplateExchangeTagsProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.metrics.web.client.DefaultRestTemplateExchangeTagsProvider",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/client/RestTemplateMetricsConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.jta.JtaAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet.WebMvcEndpointManagementContextConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet.WebMvcEndpointManagementContextConfiguration",
					"resource": null,
					"dependencies": []
				},
				"viewResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.view.ContentNegotiatingViewResolver",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter.class]",
					"dependencies": ["org.springframework.beans.factory.support.DefaultListableBeanFactory@35399441"]
				},
				"management.endpoints.web.cors-org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"methodValidationPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.validation.beanvalidation.MethodValidationPostProcessor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/validation/ValidationAutoConfiguration.class]",
					"dependencies": ["environment"]
				},
				"stringHttpMessageConverter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.http.converter.StringHttpMessageConverter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/http/HttpMessageConvertersAutoConfiguration$StringHttpMessageConverterConfiguration.class]",
					"dependencies": ["spring.http-org.springframework.boot.autoconfigure.http.HttpProperties"]
				},
				"projectingArgumentResolverBeanPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.config.ProjectingArgumentResolverRegistrar$ProjectingArgumentResolverBeanPostProcessor",
					"resource": "class path resource [org/springframework/data/web/config/ProjectingArgumentResolverRegistrar.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration$TomcatWebServerFactoryCustomizerConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration$TomcatWebServerFactoryCustomizerConfiguration",
					"resource": null,
					"dependencies": []
				},
				"tomcatServletWebServerFactoryCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.TomcatServletWebServerFactoryCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfiguration.class]",
					"dependencies": ["server-org.springframework.boot.autoconfigure.web.ServerProperties"]
				},
				"org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.admin.SpringApplicationAdminJmxAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"server-org.springframework.boot.autoconfigure.web.ServerProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.ServerProperties",
					"resource": null,
					"dependencies": []
				},
				"messageConverters": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.HttpMessageConverters",
					"resource": "class path resource [org/springframework/boot/autoconfigure/http/HttpMessageConvertersAutoConfiguration.class]",
					"dependencies": []
				},
				"jsonComponentModule": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.jackson.JsonComponentModule",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration.class]",
					"dependencies": []
				},
				"websocketServletWebServerCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.websocket.servlet.TomcatWebSocketServletWebServerCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/websocket/servlet/WebSocketServletAutoConfiguration$TomcatWebSocketConfiguration.class]",
					"dependencies": []
				},
				"jmxAnnotationEndpointDiscoverer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.jmx.annotation.JmxEndpointDiscoverer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/jmx/JmxEndpointAutoConfiguration.class]",
					"dependencies": ["endpointOperationParameterMapper"]
				},
				"org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration$ServletWebConfiguration$SpringMvcConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration$ServletWebConfiguration$SpringMvcConfiguration",
					"resource": null,
					"dependencies": []
				},
				"entityManagerFactoryBuilder": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]",
					"dependencies": ["jpaVendorAdapter"]
				},
				"org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.embedded.EmbeddedWebServerFactoryCustomizerAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mappingJackson2HttpMessageConverter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.http.converter.json.MappingJackson2HttpMessageConverter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/http/JacksonHttpMessageConvertersConfiguration$MappingJackson2HttpMessageConverterConfiguration.class]",
					"dependencies": ["jacksonObjectMapper"]
				},
				"org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfiguration",
					"resource": null,
					"dependencies": []
				},
				"healthAggregator": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.OrderedHealthAggregator",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/LegacyHealthEndpointCompatibilityConfiguration.class]",
					"dependencies": ["management.health.status-org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorProperties"]
				},
				"meterRegistryPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryPostProcessor",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"mbeanExporter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.jmx.export.annotation.AnnotationMBeanExporter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.class]",
					"dependencies": ["objectNamingStrategy", "org.springframework.beans.factory.support.DefaultListableBeanFactory@35399441"]
				},
				"endpointMediaTypes": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.health.HealthEndpointWebExtensionConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthEndpointWebExtensionConfiguration",
					"resource": null,
					"dependencies": []
				},
				"healthStatusAggregator": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.SimpleStatusAggregator",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]",
					"dependencies": ["healthEndpointProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"management.server-org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties",
					"resource": null,
					"dependencies": []
				},
				"mbeanServer": {
					"aliases": [],
					"scope": "singleton",
					"type": "com.sun.jmx.mbeanserver.JmxMBeanServer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.class]",
					"dependencies": []
				},
				"servletWebServerFactoryCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryAutoConfiguration.class]",
					"dependencies": ["server-org.springframework.boot.autoconfigure.web.ServerProperties"]
				},
				"mvcUrlPathHelper": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.util.UrlPathHelper",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"transactionTemplate": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.transaction.support.TransactionTemplate",
					"resource": "class path resource [org/springframework/boot/autoconfigure/transaction/TransactionAutoConfiguration$TransactionTemplateConfiguration.class]",
					"dependencies": ["transactionManager"]
				},
				"spring.security.oauth2.resourceserver-org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties",
					"resource": null,
					"dependencies": []
				},
				"dbHealthContributor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/jdbc/DataSourceHealthContributorAutoConfiguration.class]",
					"dependencies": ["dataSource"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration",
					"resource": null,
					"dependencies": ["management.metrics-org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties"]
				},
				"servletMappingDescriptionProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.web.mappings.servlet.ServletsMappingDescriptionProvider",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/mappings/MappingsEndpointAutoConfiguration$ServletWebConfiguration.class]",
					"dependencies": []
				},
				"webServerFactoryCustomizerBeanPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.transaction.annotation.ProxyTransactionManagementConfiguration",
					"resource": null,
					"dependencies": []
				},
				"metricsHttpClientUriTagFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.config.MeterFilter$9",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/client/HttpClientMetricsAutoConfiguration.class]",
					"dependencies": ["management.metrics-org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties"]
				},
				"org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"management.health.diskspace-org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthIndicatorProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthIndicatorProperties",
					"resource": null,
					"dependencies": []
				},
				"controllerEndpointHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.servlet.ControllerEndpointHandlerMapping",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/servlet/WebMvcEndpointManagementContextConfiguration.class]",
					"dependencies": ["controllerEndpointDiscoverer", "management.endpoints.web.cors-org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties", "management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.health.LegacyHealthEndpointCompatibilityConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.LegacyHealthEndpointCompatibilityConfiguration",
					"resource": null,
					"dependencies": []
				},
				"management.endpoint.env-org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration$JpaWebConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration$JpaWebConfiguration",
					"resource": null,
					"dependencies": ["spring.jpa-org.springframework.boot.autoconfigure.orm.jpa.JpaProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.JvmMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.JvmMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.JdbcTemplateAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$Jackson2ObjectMapperBuilderCustomizerConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$Jackson2ObjectMapperBuilderCustomizerConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration$StringHttpMessageConverterConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration$StringHttpMessageConverterConfiguration",
					"resource": null,
					"dependencies": []
				},
				"healthIndicatorRegistry": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthContributorRegistryHealthIndicatorRegistryAdapter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/LegacyHealthEndpointCompatibilityConfiguration.class]",
					"dependencies": ["healthContributorRegistry"]
				},
				"org.springframework.boot.actuate.autoconfigure.management.ThreadDumpEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.management.ThreadDumpEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"standardJacksonObjectMapperBuilderCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$Jackson2ObjectMapperBuilderCustomizerConfiguration$StandardJackson2ObjectMapperBuilderCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration$Jackson2ObjectMapperBuilderCustomizerConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "spring.jackson-org.springframework.boot.autoconfigure.jackson.JacksonProperties"]
				},
				"taskSchedulerBuilder": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.task.TaskSchedulerBuilder",
					"resource": "class path resource [org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.class]",
					"dependencies": ["spring.task.scheduling-org.springframework.boot.autoconfigure.task.TaskSchedulingProperties"]
				},
				"metricsEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.metrics.MetricsEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/MetricsEndpointAutoConfiguration.class]",
					"dependencies": ["simpleMeterRegistry"]
				},
				"org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.aop.AopAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.info.InfoContributorAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.orm.jpa.HibernateMetricsAutoConfiguration",
					"resource": null,
					"dependencies": ["entityManagerFactory", "simpleMeterRegistry"]
				},
				"topicRepository": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.topic.TopicRepository",
					"resource": null,
					"dependencies": ["(inner bean)#30a791a6", "(inner bean)#6942ee48", "(inner bean)#70cd122", "jpaMappingContext"]
				},
				"simpleMeterRegistry": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.simple.SimpleMeterRegistry",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.class]",
					"dependencies": ["simpleConfig", "micrometerClock"]
				},
				"org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.jpa.hibernate-org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties",
					"resource": null,
					"dependencies": []
				},
				"environmentEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.env.EnvironmentEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.class]",
					"dependencies": ["environment", "management.endpoint.env-org.springframework.boot.actuate.autoconfigure.env.EnvironmentEndpointProperties"]
				},
				"entityManagerFactory": {
					"aliases": [],
					"scope": "singleton",
					"type": "com.sun.proxy.$Proxy96",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]",
					"dependencies": ["entityManagerFactoryBuilder"]
				},
				"healthStatusHttpMapper": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.HealthStatusHttpMapper",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/LegacyHealthEndpointCompatibilityConfiguration.class]",
					"dependencies": ["management.health.status-org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorProperties"]
				},
				"conventionErrorViewResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.DefaultErrorViewResolver",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration$DefaultErrorViewResolverConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$EnableWebMvcConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$EnableWebMvcConfiguration",
					"resource": null,
					"dependencies": ["spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties", "org.springframework.beans.factory.support.DefaultListableBeanFactory@35399441", "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter", "openEntityManagerInViewInterceptorConfigurer", "metricsWebMvcConfigurer", "org.springframework.data.web.config.SpringDataWebConfiguration"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.LogbackMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties",
					"resource": null,
					"dependencies": []
				},
				"localeCharsetMappingsCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration$LocaleCharsetMappingsCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/HttpEncodingAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.logging.LoggersEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.logging.LoggersEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"configurationPropertiesReportEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/context/properties/ConfigurationPropertiesReportEndpointAutoConfiguration.class]",
					"dependencies": ["management.endpoint.configprops-org.springframework.boot.actuate.autoconfigure.context.properties.ConfigurationPropertiesReportEndpointProperties"]
				},
				"formContentFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.servlet.filter.OrderedFormContentFilter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration.class]",
					"dependencies": []
				},
				"multipartConfigElement": {
					"aliases": [],
					"scope": "singleton",
					"type": "javax.servlet.MultipartConfigElement",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/MultipartAutoConfiguration.class]",
					"dependencies": []
				},
				"requestContextFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.servlet.filter.OrderedRequestContextFilter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter.class]",
					"dependencies": []
				},
				"defaultViewResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.view.InternalResourceViewResolver",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$EnableTransactionManagementConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$EnableTransactionManagementConfiguration",
					"resource": null,
					"dependencies": []
				},
				"routerFunctionMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.function.support.RouterFunctionMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcConversionService", "mvcResourceUrlProvider"]
				},
				"jacksonObjectMapperBuilder": {
					"aliases": [],
					"scope": "prototype",
					"type": "org.springframework.http.converter.json.Jackson2ObjectMapperBuilder",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration$JacksonObjectMapperBuilderConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "standardJacksonObjectMapperBuilderCustomizer"]
				},
				"org.springframework.boot.autoconfigure.dao.PersistenceExceptionTranslationAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.dao.PersistenceExceptionTranslationAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration$ServletWebConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration$ServletWebConfiguration",
					"resource": null,
					"dependencies": []
				},
				"beansEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.beans.BeansEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/beans/BeansEndpointAutoConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"management.endpoints.jmx-org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"spring.task.scheduling-org.springframework.boot.autoconfigure.task.TaskSchedulingProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.task.TaskSchedulingProperties",
					"resource": null,
					"dependencies": []
				},
				"webMvcMetricsFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.servlet.FilterRegistrationBean",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfiguration.class]",
					"dependencies": ["simpleMeterRegistry", "webMvcTagsProvider"]
				},
				"pageableResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.PageableHandlerMethodArgumentResolver",
					"resource": "class path resource [org/springframework/data/web/config/SpringDataWebConfiguration.class]",
					"dependencies": ["sortResolver"]
				},
				"healthEndpointWebExtension": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.HealthEndpointWebExtension",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointWebExtensionConfiguration.class]",
					"dependencies": ["healthContributorRegistry", "healthEndpointGroups"]
				},
				"restTemplateBuilder": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.client.RestTemplateBuilder",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfiguration.class]",
					"dependencies": []
				},
				"multipartResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.multipart.support.StandardServletMultipartResolver",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/MultipartAutoConfiguration.class]",
					"dependencies": []
				},
				"handlerFunctionAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.function.support.HandlerFunctionAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration$WebEndpointServletConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration$WebEndpointServletConfiguration",
					"resource": null,
					"dependencies": []
				},
				"requestMappingHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcContentNegotiationManager", "mvcConversionService", "mvcResourceUrlProvider"]
				},
				"webExposeExcludePropertyEndpointFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.ExposeExcludePropertyEndpointFilter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration$SameManagementContextConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration$SameManagementContextConfiguration",
					"resource": null,
					"dependencies": ["environment"]
				},
				"requestMappingHandlerAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcContentNegotiationManager", "mvcConversionService", "mvcValidator", "sortResolver", "pageableResolver"]
				},
				"org.springframework.boot.autoconfigure.jdbc.NamedParameterJdbcTemplateConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.NamedParameterJdbcTemplateConfiguration",
					"resource": null,
					"dependencies": []
				},
				"tomcatMetricsBinder": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.metrics.web.tomcat.TomcatMetricsBinder",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/tomcat/TomcatMetricsAutoConfiguration.class]",
					"dependencies": ["simpleMeterRegistry"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration$DataSourcePoolMetadataMetricsConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration$DataSourcePoolMetadataMetricsConfiguration",
					"resource": null,
					"dependencies": ["dataSource", "simpleMeterRegistry"]
				},
				"spring.transaction-org.springframework.boot.autoconfigure.transaction.TransactionProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.health.LegacyHealthEndpointAdaptersConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.LegacyHealthEndpointAdaptersConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.HttpEncodingAutoConfiguration",
					"resource": null,
					"dependencies": ["spring.http-org.springframework.boot.autoconfigure.http.HttpProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.web.ServletEndpointManagementContextConfiguration$WebMvcServletEndpointManagementContextConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.ServletEndpointManagementContextConfiguration$WebMvcServletEndpointManagementContextConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.data.jpa.repository.support.JpaEvaluationContextExtension": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.jpa.repository.support.JpaEvaluationContextExtension",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.logging.LogFileWebEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.logging.LogFileWebEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"springApplicationAdminRegistrar": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.admin.SpringApplicationAdminMXBeanRegistrar",
					"resource": "class path resource [org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.class]",
					"dependencies": ["environment"]
				},
				"spring.info-org.springframework.boot.autoconfigure.info.ProjectInfoProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.info.ProjectInfoProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.MetricsEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"endpointOperationParameterMapper": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.invoke.convert.ConversionServiceParameterValueMapper",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/EndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"infoEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.info.InfoEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/info/InfoEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.web.client.HttpClientMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.web.client.HttpClientMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.ResourceProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthContributorAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"jpaVendorAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]",
					"dependencies": []
				},
				"management.health.status-org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"classLoaderMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"servletWebChildContextFactory": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextFactory",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/servlet/ServletManagementContextAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.internalCachingMetadataReaderFactory": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.core.type.classreading.CachingMetadataReaderFactory",
					"resource": null,
					"dependencies": []
				},
				"jacksonGeoModule": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.geo.GeoModule",
					"resource": "class path resource [org/springframework/data/web/config/SpringDataJacksonConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$ParameterNamesModuleConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$ParameterNamesModuleConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mvcContentNegotiationManager": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.accept.ContentNegotiationManager",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"objectNamingStrategy": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jmx.ParentAwareNamingStrategy",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.class]",
					"dependencies": []
				},
				"sortResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.SortHandlerMethodArgumentResolver",
					"resource": "class path resource [org/springframework/data/web/config/SpringDataWebConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration$HikariDataSourceMetricsConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration$HikariDataSourceMetricsConfiguration",
					"resource": null,
					"dependencies": ["simpleMeterRegistry", "dataSource"]
				},
				"org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.audit.AuditEventsEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.audit.AuditEventsEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"errorAttributes": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.servlet.error.DefaultErrorAttributes",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.class]",
					"dependencies": []
				},
				"httpRequestHandlerAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.mappings.MappingsEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"beanNameHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.handler.BeanNameUrlHandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcConversionService", "mvcResourceUrlProvider"]
				},
				"org.springframework.boot.actuate.autoconfigure.health.HealthEndpointConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthEndpointConfiguration",
					"resource": null,
					"dependencies": []
				},
				"webMvcTagsProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.metrics.web.servlet.DefaultWebMvcTagsProvider",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"spring.servlet.multipart-org.springframework.boot.autoconfigure.web.servlet.MultipartProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.MultipartProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration",
					"resource": null,
					"dependencies": ["spring.info-org.springframework.boot.autoconfigure.info.ProjectInfoProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMetricsConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.web.client.RestTemplateMetricsConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryConfiguration$EmbeddedTomcat": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryConfiguration$EmbeddedTomcat",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.management.HeapDumpWebEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.management.HeapDumpWebEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceConfiguration$Hikari": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceConfiguration$Hikari",
					"resource": null,
					"dependencies": []
				},
				"resourceHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.handler.SimpleUrlHandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcUrlPathHelper", "mvcPathMatcher", "mvcContentNegotiationManager", "mvcConversionService", "mvcResourceUrlProvider"]
				},
				"simpleControllerHandlerAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.mvc.SimpleControllerHandlerAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"spring.http-org.springframework.boot.autoconfigure.http.HttpProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.HttpProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.data.web.config.SpringDataJacksonConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.config.SpringDataJacksonConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfiguration$Hikari": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceJmxConfiguration$Hikari",
					"resource": null,
					"dependencies": ["dataSource"]
				},
				"cachesEndpointWebExtension": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.cache.CachesEndpointWebExtension",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/cache/CachesEndpointAutoConfiguration.class]",
					"dependencies": ["cachesEndpoint"]
				},
				"org.springframework.boot.actuate.autoconfigure.context.properties.ConfigurationPropertiesReportEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.context.properties.ConfigurationPropertiesReportEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"management.metrics-org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties",
					"resource": null,
					"dependencies": []
				},
				"healthContributorRegistry": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.AutoConfiguredHealthContributorRegistry",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "healthEndpointGroups"]
				},
				"management.endpoint.configprops-org.springframework.boot.actuate.autoconfigure.context.properties.ConfigurationPropertiesReportEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.context.properties.ConfigurationPropertiesReportEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"parameterNamesModule": {
					"aliases": [],
					"scope": "singleton",
					"type": "com.fasterxml.jackson.module.paramnames.ParameterNamesModule",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration$ParameterNamesModuleConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceInitializationConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceInitializationConfiguration",
					"resource": null,
					"dependencies": []
				},
				"micrometerClock": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.Clock$1",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"topicController": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.topic.TopicController",
					"resource": "file [/Users/oblavat/personal/course-api-data/target/classes/io/javabrains/topic/TopicController.class]",
					"dependencies": ["topicService"]
				},
				"org.springframework.boot.actuate.autoconfigure.beans.BeansEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.beans.BeansEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"propertiesMeterFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.PropertiesMeterFilter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/MetricsAutoConfiguration.class]",
					"dependencies": ["management.metrics-org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties"]
				},
				"healthHttpCodeStatusMapper": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.SimpleHttpCodeStatusMapper",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]",
					"dependencies": ["healthEndpointProperties"]
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerInvoker": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceInitializerInvoker",
					"resource": null,
					"dependencies": ["spring.datasource-org.springframework.boot.autoconfigure.jdbc.DataSourceProperties", "org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"uptimeMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.system.UptimeMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"controllerExposeExcludePropertyEndpointFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.ExposeExcludePropertyEndpointFilter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"pathMappedEndpoints": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": ["jmxAnnotationEndpointDiscoverer", "servletEndpointDiscoverer", "webEndpointDiscoverer", "controllerEndpointDiscoverer"]
				},
				"jvmThreadMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"scheduledTasksEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.scheduling.ScheduledTasksEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/scheduling/ScheduledTasksEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.data.web.config.ProjectingArgumentResolverRegistrar": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.config.ProjectingArgumentResolverRegistrar$$EnhancerBySpringCGLIB$$c8a2ebbf",
					"resource": null,
					"dependencies": []
				},
				"heapDumpWebEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.management.HeapDumpWebEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/management/HeapDumpWebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"managementServletContext": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration$$Lambda$985/0x0000000801923040",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/servlet/ServletManagementContextAutoConfiguration.class]",
					"dependencies": ["management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties"]
				},
				"fileDescriptorMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.system.FileDescriptorMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.data.jpa.util.JpaMetamodelCacheCleanup": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.jpa.util.JpaMetamodelCacheCleanup",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration$CglibAutoProxyConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration$CglibAutoProxyConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration",
					"resource": null,
					"dependencies": ["server-org.springframework.boot.autoconfigure.web.ServerProperties"]
				},
				"servletEndpointDiscoverer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointDiscoverer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration$WebEndpointServletConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"emBeanDefinitionRegistrarPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.jpa.repository.support.EntityManagerBeanDefinitionRegistrarPostProcessor",
					"resource": null,
					"dependencies": []
				},
				"environmentEndpointWebExtension": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.env.EnvironmentEndpointWebExtension",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/env/EnvironmentEndpointAutoConfiguration.class]",
					"dependencies": ["environmentEndpoint"]
				},
				"metricsHttpServerUriTagFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.config.MeterFilter$9",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"mvcValidator": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.validation.ValidatorAdapter",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration$TomcatWebSocketConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration$TomcatWebSocketConfiguration",
					"resource": null,
					"dependencies": []
				},
				"conditionsReportEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/condition/ConditionsReportEndpointAutoConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mvcResourceUrlProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.resource.ResourceUrlProvider",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"healthEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.HealthEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointConfiguration.class]",
					"dependencies": ["healthContributorRegistry", "healthEndpointGroups"]
				},
				"org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration$SameManagementContextConfiguration$EnableSameManagementContextConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration$SameManagementContextConfiguration$EnableSameManagementContextConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.task.execution-org.springframework.boot.autoconfigure.task.TaskExecutionProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.task.TaskExecutionProperties",
					"resource": null,
					"dependencies": []
				},
				"viewControllerHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.HandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcPathMatcher", "mvcUrlPathHelper", "mvcConversionService", "mvcResourceUrlProvider"]
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration$PooledDataSourceConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration$PooledDataSourceConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"servletEndpointRegistrar": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.ServletEndpointRegistrar",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration$WebMvcServletEndpointManagementContextConfiguration.class]",
					"dependencies": ["management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties", "servletEndpointDiscoverer", "dispatcherServletRegistration"]
				},
				"dumpEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.management.ThreadDumpEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/management/ThreadDumpEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"dispatcherServlet": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.DispatcherServlet",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfiguration$DispatcherServletConfiguration.class]",
					"dependencies": ["spring.http-org.springframework.boot.autoconfigure.http.HttpProperties", "spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.web.ServletEndpointManagementContextConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.ServletEndpointManagementContextConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.jdbc.DataSourceHealthContributorAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.jdbc.DataSourceHealthContributorAutoConfiguration",
					"resource": null,
					"dependencies": ["dataSource"]
				},
				"webEndpointServletHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/servlet/WebMvcEndpointManagementContextConfiguration.class]",
					"dependencies": ["webEndpointDiscoverer", "servletEndpointDiscoverer", "controllerEndpointDiscoverer", "endpointMediaTypes", "management.endpoints.web.cors-org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties", "management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties", "environment"]
				},
				"hikariPoolDataSourceMetadataProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration$$Lambda$667/0x000000080151bc40",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jdbc/metadata/DataSourcePoolMetadataProvidersConfiguration$HikariPoolDataSourceMetadataProviderConfiguration.class]",
					"dependencies": []
				},
				"processorMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.system.ProcessorMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/SystemMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"dispatcherServletMappingDescriptionProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.web.mappings.servlet.DispatcherServletsMappingDescriptionProvider",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/mappings/MappingsEndpointAutoConfiguration$ServletWebConfiguration$SpringMvcConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.scheduling.ScheduledTasksEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.scheduling.ScheduledTasksEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.jdbc-org.springframework.boot.autoconfigure.jdbc.JdbcProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.JdbcProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration$WebMvcAutoConfigurationAdapter",
					"resource": null,
					"dependencies": ["spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties", "spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties", "org.springframework.beans.factory.support.DefaultListableBeanFactory@35399441"]
				},
				"org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration$DataSourceTransactionManagerConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration$DataSourceTransactionManagerConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.data.web.config.SpringDataWebConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.web.config.SpringDataWebConfiguration$$EnhancerBySpringCGLIB$$f38fb121",
					"resource": null,
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"transactionManager": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.orm.jpa.JpaTransactionManager",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]",
					"dependencies": []
				},
				"healthEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthEndpointProperties",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthEndpointAutoConfiguration.class]",
					"dependencies": ["management.health.status-org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorProperties"]
				},
				"errorPageRegistrarBeanPostProcessor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.server.ErrorPageRegistrarBeanPostProcessor",
					"resource": null,
					"dependencies": []
				},
				"errorPageCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$ErrorPageCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.class]",
					"dependencies": ["dispatcherServletRegistration"]
				},
				"mvcConversionService": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.format.WebConversionService",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"metricsWebMvcConfigurer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration$MetricsWebMvcConfigurer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/web/servlet/WebMvcMetricsAutoConfiguration.class]",
					"dependencies": ["simpleMeterRegistry", "webMvcTagsProvider"]
				},
				"loggersEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.logging.LoggersEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/logging/LoggersEndpointAutoConfiguration.class]",
					"dependencies": ["springBootLoggingSystem"]
				},
				"org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$DefaultErrorViewResolverConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$DefaultErrorViewResolverConfiguration",
					"resource": null,
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "spring.resources-org.springframework.boot.autoconfigure.web.ResourceProperties"]
				},
				"jmxIncludeExcludePropertyEndpointFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.ExposeExcludePropertyEndpointFilter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/jmx/JmxEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"openEntityManagerInViewInterceptorConfigurer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration$JpaWebConfiguration$1",
					"resource": "class path resource [org/springframework/boot/autoconfigure/orm/jpa/JpaBaseConfiguration$JpaWebConfiguration.class]",
					"dependencies": ["openEntityManagerInViewInterceptor"]
				},
				"controllerEndpointDiscoverer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointDiscoverer",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/WebEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"courseRepository": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.course.CourseRepository",
					"resource": null,
					"dependencies": ["(inner bean)#11170228", "(inner bean)#4a41caed", "(inner bean)#1dd76982", "jpaMappingContext"]
				},
				"diskSpaceHealthIndicator": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.system.DiskSpaceHealthIndicator",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/system/DiskSpaceHealthContributorAutoConfiguration.class]",
					"dependencies": ["management.health.diskspace-org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthIndicatorProperties"]
				},
				"tomcatWebServerFactoryCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.embedded.TomcatWebServerFactoryCustomizer",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/embedded/EmbeddedWebServerFactoryCustomizerAutoConfiguration$TomcatWebServerFactoryCustomizerConfiguration.class]",
					"dependencies": ["environment", "server-org.springframework.boot.autoconfigure.web.ServerProperties"]
				},
				"jvmMemoryMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.http.JacksonHttpMessageConvertersConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.JacksonHttpMessageConvertersConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mvcPathMatcher": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.util.AntPathMatcher",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": []
				},
				"handlerExceptionResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.handler.HandlerExceptionResolverComposite",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcContentNegotiationManager"]
				},
				"org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthContributorAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.system.DiskSpaceHealthContributorAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"management.metrics.export.simple-org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"basicErrorController": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration.class]",
					"dependencies": ["errorAttributes"]
				},
				"cachesEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.cache.CachesEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/cache/CachesEndpointAutoConfiguration.class]",
					"dependencies": []
				},
				"pingHealthContributor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.health.PingHealthIndicator",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/health/HealthContributorAutoConfiguration.class]",
					"dependencies": []
				},
				"dispatcherServletRegistration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.DispatcherServletRegistrationBean",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/DispatcherServletAutoConfiguration$DispatcherServletRegistrationConfiguration.class]",
					"dependencies": ["dispatcherServlet", "spring.mvc-org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties"]
				},
				"pageableCustomizer": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration$$Lambda$927/0x00000008018de040",
					"resource": "class path resource [org/springframework/boot/autoconfigure/data/web/SpringDataWebAutoConfiguration.class]",
					"dependencies": []
				},
				"dataSource": {
					"aliases": [],
					"scope": "singleton",
					"type": "com.zaxxer.hikari.HikariDataSource",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jdbc/DataSourceConfiguration$Hikari.class]",
					"dependencies": ["spring.datasource-org.springframework.boot.autoconfigure.jdbc.DataSourceProperties"]
				},
				"mappingsEndpoint": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.web.mappings.MappingsEndpoint",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/mappings/MappingsEndpointAutoConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9"]
				},
				"management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"courseApiDataApplication": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.CourseApiDataApplication$$EnhancerBySpringCGLIB$$1fe790c1",
					"resource": null,
					"dependencies": []
				},
				"tomcatServletWebServerFactory": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/ServletWebServerFactoryConfiguration$EmbeddedTomcat.class]",
					"dependencies": []
				},
				"jpaMappingContext": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.data.jpa.mapping.JpaMetamodelMappingContext",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.http.JacksonHttpMessageConvertersConfiguration$MappingJackson2HttpMessageConverterConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.http.JacksonHttpMessageConvertersConfiguration$MappingJackson2HttpMessageConverterConfiguration",
					"resource": null,
					"dependencies": []
				},
				"spring.jackson-org.springframework.boot.autoconfigure.jackson.JacksonProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonProperties",
					"resource": null,
					"dependencies": []
				},
				"error": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$StaticView",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/error/ErrorMvcAutoConfiguration$WhitelabelErrorViewConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration",
					"resource": null,
					"dependencies": ["spring.data.web-org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties"]
				},
				"spring.datasource-org.springframework.boot.autoconfigure.jdbc.DataSourceProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.DataSourceProperties",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$JacksonObjectMapperConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration$JacksonObjectMapperConfiguration",
					"resource": null,
					"dependencies": []
				},
				"namedParameterJdbcTemplate": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jdbc/NamedParameterJdbcTemplateConfiguration.class]",
					"dependencies": ["jdbcTemplate"]
				},
				"org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$WhitelabelErrorViewConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration$WhitelabelErrorViewConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration$DispatcherServletConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration$DispatcherServletConfiguration",
					"resource": null,
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration",
					"resource": null,
					"dependencies": ["environment"]
				},
				"jvmGcMetrics": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.micrometer.core.instrument.binder.jvm.JvmGcMetrics",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.class]",
					"dependencies": []
				},
				"org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$TransactionTemplateConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration$TransactionTemplateConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mvcViewResolver": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.servlet.view.ViewResolverComposite",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcContentNegotiationManager"]
				},
				"simpleConfig": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimplePropertiesConfigAdapter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/metrics/export/simple/SimpleMetricsExportAutoConfiguration.class]",
					"dependencies": ["management.metrics.export.simple-org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleProperties"]
				},
				"welcomePageHandlerMapping": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.web.servlet.WelcomePageHandlerMapping",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@20140db9", "mvcConversionService", "mvcResourceUrlProvider"]
				},
				"org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"servletExposeExcludePropertyEndpointFilter": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.endpoint.ExposeExcludePropertyEndpointFilter",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/endpoint/web/ServletEndpointManagementContextConfiguration.class]",
					"dependencies": ["management.endpoints.web-org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties"]
				},
				"org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.servlet.ServletManagementContextAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"mvcUriComponentsContributor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.web.method.support.CompositeUriComponentsContributor",
					"resource": "class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]",
					"dependencies": ["mvcConversionService", "requestMappingHandlerAdapter"]
				},
				"courseService": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.course.CourseService",
					"resource": "file [/Users/oblavat/personal/course-api-data/target/classes/io/javabrains/course/CourseService.class]",
					"dependencies": ["courseRepository"]
				},
				"filterMappingDescriptionProvider": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.web.mappings.servlet.FiltersMappingDescriptionProvider",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/web/mappings/MappingsEndpointAutoConfiguration$ServletWebConfiguration.class]",
					"dependencies": []
				},
				"topicService": {
					"aliases": [],
					"scope": "singleton",
					"type": "io.javabrains.topic.TopicService",
					"resource": "file [/Users/oblavat/personal/course-api-data/target/classes/io/javabrains/topic/TopicService.class]",
					"dependencies": ["topicRepository"]
				},
				"org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration",
					"resource": null,
					"dependencies": []
				},
				"jacksonObjectMapper": {
					"aliases": [],
					"scope": "singleton",
					"type": "com.fasterxml.jackson.databind.ObjectMapper",
					"resource": "class path resource [org/springframework/boot/autoconfigure/jackson/JacksonAutoConfiguration$JacksonObjectMapperConfiguration.class]",
					"dependencies": ["jacksonObjectMapperBuilder"]
				},
				"envInfoContributor": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.info.EnvironmentInfoContributor",
					"resource": "class path resource [org/springframework/boot/actuate/autoconfigure/info/InfoContributorAutoConfiguration.class]",
					"dependencies": ["environment"]
				},
				"management.endpoint.logfile-org.springframework.boot.actuate.autoconfigure.logging.LogFileWebEndpointProperties": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.actuate.autoconfigure.logging.LogFileWebEndpointProperties",
					"resource": null,
					"dependencies": []
				},
				"taskExecutorBuilder": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.task.TaskExecutorBuilder",
					"resource": "class path resource [org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.class]",
					"dependencies": ["spring.task.execution-org.springframework.boot.autoconfigure.task.TaskExecutionProperties"]
				},
				"org.springframework.boot.autoconfigure.jdbc.JdbcTemplateConfiguration": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.jdbc.JdbcTemplateConfiguration",
					"resource": null,
					"dependencies": []
				},
				"platformTransactionManagerCustomizers": {
					"aliases": [],
					"scope": "singleton",
					"type": "org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers",
					"resource": "class path resource [org/springframework/boot/autoconfigure/transaction/TransactionAutoConfiguration.class]",
					"dependencies": []
				}
			},
			"parentId": null
		}
	}
}
```
# References
https://www.baeldung.com/spring-boot-actuators